### PR TITLE
Change error message when no option is provided.

### DIFF
--- a/amqpeek/cli.py
+++ b/amqpeek/cli.py
@@ -126,7 +126,7 @@ def main(config, interval, verbosity, max_tests, gen_config):
             click.style(
                 'No configuration file found. '
                 'Specify a configuration file with --config. '
-                'To generate a base config file use --gen-config.',
+                'To generate a base config file use --gen_config.',
                 fg='red'
             )
         )

--- a/test/interface/cli/test_main.py
+++ b/test/interface/cli/test_main.py
@@ -108,7 +108,7 @@ class TestCli(object):
         assert result.output == (
             'No configuration file found. '
             'Specify a configuration file with --config. '
-            'To generate a base config file use --gen-config.\n'
+            'To generate a base config file use --gen_config.\n'
         )
 
     def test_create_config(


### PR DESCRIPTION
Correct option is `--gen_config` not `--gen-config`.