### PR TITLE
Send notification when queue is no declared

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,8 @@ AMQPeek
 .. pull-quote::
 
     A flexible RMQ monitor that keeps track of RMQ, notifying you over multiple channels when
-    connections cannot be made, and when queue lengths increase beyond specified limits.
+    connections cannot be made, queues have not been declared, and when queue
+    lengths increase beyond specified limits.
 
 Install
 -------

--- a/amqpeek/monitor.py
+++ b/amqpeek/monitor.py
@@ -112,9 +112,7 @@ class Monitor(object):
 
         for queue_name, queue_config in queue_details.items():
             try:
-                queue = self.connect_to_queue(
-                    channel, queue_name, queue_config
-                )
+                queue = self.connect_to_queue(channel, queue_name)
             except ChannelClosed:
                 subject = 'Queue does not exist'
                 message = (
@@ -150,17 +148,16 @@ class Monitor(object):
         for notifier in self.notifiers:
             notifier.notify(subject, message)
 
-    def connect_to_queue(self, channel, queue_name, queue_config):
+    def connect_to_queue(self, channel, queue_name):
         """
         :param: channel: pika.channel.Channel
         :param: queue_name: string
-        :param: queue_config: dict
         :return: pika.frame.Method
+        :raises: pika.ChannelClosed
         """
         return channel.queue_declare(
             queue=queue_name,
             passive=True,
-            **queue_config['settings']
         )
 
     def get_channel(self, connection):

--- a/config/amqpeek.yaml
+++ b/config/amqpeek.yaml
@@ -1,7 +1,5 @@
 # RMQ connection details
-# Uncomment credentials and add username and password if required
 rabbit_connection: {
-  #credentials: { user: user, passwd: passwd },
   user: guest,
   passwd: guest,
   host: localhost,
@@ -11,22 +9,14 @@ rabbit_connection: {
 
 # Queues to monitor.
 #
-# Settings:
-# To connect to queues, we run a declear statement,
-# so add all queue settings here. See:
-# http://pika.readthedocs.io/en/latest/modules/channel.html#pika.channel.Channel.queue_declare
-# for all options used here.
-#
 # limit:
 # max items in queue before notification is sent
 queues:
   my_queue: {
-      'settings': {'durable': true},
       'limit': 0
   }
 
   my_other_queue: {
-      'settings': {'durable': true},
       'limit': 0
   }
 

--- a/test/unit/monitor/test_monitor.py
+++ b/test/unit/monitor/test_monitor.py
@@ -1,6 +1,6 @@
 import pytest
 from mock import Mock, patch
-from pika.exceptions import AMQPConnectionError
+from pika.exceptions import AMQPConnectionError, ChannelClosed
 
 from amqpeek.monitor import Monitor
 from amqpeek.notifier import Notifier
@@ -53,6 +53,7 @@ class TestMonitor(object):
         monitor.get_queue_message_count.assert_called()
         channel_mock.queue_declare.assert_called_once_with(
             queue='test_queue_1',
+            passive=True,
             durable=True
         )
 
@@ -73,6 +74,16 @@ class TestMonitor(object):
         monitor.notifiers[0].notify.assert_called_once_with(
             'Queue Length Error',
             'Queue "test_queue_1" is over specified limit!! (101 > 100)'
+        )
+
+    def test_run_queue_not_declared_send_correct_notifcation(self, monitor):
+        monitor.connect_to_queue = Mock(side_effect=ChannelClosed)
+
+        monitor.run()
+
+        monitor.notifiers[0].notify.assert_called_once_with(
+            'Queue does not exist',
+            'Queue "test_queue_1" has not been declared'
         )
 
     @patch('amqpeek.monitor.time')

--- a/test/unit/monitor/test_monitor.py
+++ b/test/unit/monitor/test_monitor.py
@@ -14,7 +14,6 @@ class TestMonitor(object):
             connector=Mock(),
             queue_details={
                 'test_queue_1': {
-                    'settings': {'durable': True},
                     'limit': 100
                 }
             },
@@ -54,7 +53,6 @@ class TestMonitor(object):
         channel_mock.queue_declare.assert_called_once_with(
             queue='test_queue_1',
             passive=True,
-            durable=True
         )
 
     def test_run_no_errors_found_do_not_notify(self, monitor):


### PR DESCRIPTION
Instead of actually declaring the queue when connecting to it, we now passively connect to the queue, and send a notification if the queue has not already beed declared

The added bonus of this is that it simplifies the setup of monitored queues, as you no longer have to give all of the declaration parameters.