### PR TITLE
Allow queues to be defined by grouping them by limit

### DIFF
--- a/amqpeek/monitor.py
+++ b/amqpeek/monitor.py
@@ -110,7 +110,7 @@ class Monitor(object):
         """
         channel = self.get_channel(connection)
 
-        for queue_name, queue_config in queue_details.items():
+        for queue_name, queue_limit in queue_details:
             try:
                 queue = self.connect_to_queue(channel, queue_name)
             except ChannelClosed:
@@ -122,11 +122,11 @@ class Monitor(object):
                 logging.info('%s - %s', subject, message)
                 self.notify(subject, message)
 
-                return
+                continue
 
             message_count = self.get_queue_message_count(queue)
 
-            if message_count > queue_config['limit']:
+            if message_count > queue_limit:
                 subject = 'Queue Length Error'
                 message = (
                     'Queue "{queue}" is over specified limit!! '
@@ -134,7 +134,7 @@ class Monitor(object):
                 ).format(
                     queue=queue_name,
                     message_count=message_count,
-                    limit=queue_config['limit']
+                    limit=queue_limit
                 )
 
                 logging.info('%s - %s', subject, message)

--- a/config/amqpeek.yaml
+++ b/config/amqpeek.yaml
@@ -9,6 +9,9 @@ rabbit_connection: {
 
 # Queues to monitor.
 #
+# Define a queue you wish to monitor and the warning limit of that queue
+# An alternative to defining queues is queue_limits below.
+#
 # limit:
 # max items in queue before notification is sent
 queues:
@@ -19,6 +22,19 @@ queues:
   my_other_queue: {
       'limit': 0
   }
+
+# Limits and associated queues.
+#
+# Define a number of queues grouped by limit.
+#
+# key:
+# max items in queue before notification is sent
+#
+# value:
+# list of queue names to apply the limit to
+queue_limits:
+  10: ['my_queue']
+  100: ['my_other_queue']
 
 # Active notifiers:
 #

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -20,6 +20,10 @@ def config_data():
                 'limit': 0
             }
         },
+        'queue_limits': {
+            0: ['my_queue'],
+            1: ['my_other_queue'],
+        },
         'notifiers': {
             'smtp': {
                 'host': 'localhost',

--- a/test/unit/cli/test_create_file.py
+++ b/test/unit/cli/test_create_file.py
@@ -1,9 +1,6 @@
-import os
-
 import pytest
 from mock import patch
 
-from amqpeek import cli
 from amqpeek.cli import gen_config_file
 from amqpeek.exceptions import ConfigExistsError
 

--- a/test/unit/cli/test_format_queues.py
+++ b/test/unit/cli/test_format_queues.py
@@ -1,0 +1,45 @@
+from copy import deepcopy
+
+from amqpeek.cli import build_queue_data
+
+
+class TestFormatQueues:
+    def test_dedup_queue_config(self, config_data):
+        """
+        my_queue is defined twice, both in queues and queue_limits
+        build_queue_data should dedup queues defined twice if their limits
+        are the same
+        """
+        result = build_queue_data(config_data)
+
+        assert isinstance(result, set)
+        assert len(result) == 2
+
+        expected_queues = set([('my_queue', 0), ('my_other_queue', 1)])
+        for excepted_queue in expected_queues:
+            assert excepted_queue in result
+
+    def test_just_queue_config(self, config_data):
+        config_data = deepcopy(config_data)
+        del(config_data['queue_limits'])
+
+        result = build_queue_data(config_data)
+
+        assert result == {('my_queue', 0)}
+
+    def test_just_queue_limits_config(self, config_data):
+        config_data = deepcopy(config_data)
+        del(config_data['queues'])
+
+        result = build_queue_data(config_data)
+
+        assert len(result) == 2
+
+        expected_queues = set([('my_queue', 0), ('my_other_queue', 1)])
+        for excepted_queue in expected_queues:
+            assert excepted_queue in result
+
+    def test_no_queue_config(self):
+        result = build_queue_data({})
+
+        assert result == set([])

--- a/test/unit/monitor/test_monitor.py
+++ b/test/unit/monitor/test_monitor.py
@@ -12,11 +12,7 @@ class TestMonitor(object):
     def monitor(self):
         monitor = Monitor(
             connector=Mock(),
-            queue_details={
-                'test_queue_1': {
-                    'limit': 100
-                }
-            },
+            queue_details=[('test_queue_1', 100)],
             interval=None
         )
 
@@ -64,7 +60,8 @@ class TestMonitor(object):
 
     def test_run_queue_length_error_sends_correct_notification(self, monitor):
         monitor.get_queue_message_count = Mock(
-            return_value=monitor.queue_details['test_queue_1']['limit'] + 1
+            # the limit of test_queue_one + 1
+            return_value=monitor.queue_details[0][1] + 1
         )
 
         monitor.run()


### PR DESCRIPTION
This should help reduce the amount of config if you have a large number of queues, that have the same limit. The previous method of defining queues is still supported.

Also, fixed an issue when the monitor stopped after encountering an undefined queue