### PR TITLE
Use PyYaml SafeLoader

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ To create a base configuration file:
 
     $ amqpeek --gen_config
 
-This will create a file called ``amqpeek.yaml`` in you current directory. Here you
+This will create a file called ``amqpeek.yaml`` in your current directory. Here you
 can setup your connection details for RMQ, define queues you wish to monitor
 and define the notifier channels you wish to use. Edit this file to suit your
 needs

--- a/amqpeek/cli.py
+++ b/amqpeek/cli.py
@@ -31,7 +31,7 @@ def read_config(config):
     :return: dict
     """
     with open(config, 'r') as config_file:
-        return yaml.load(config_file)
+        return yaml.load(config_file, Loader=yaml.SafeLoader)
 
 
 def configure_logging(verbosity):


### PR DESCRIPTION
PyYaml's plain load method has been deprecated. Update the use of `load()`
method to explicitly use the `SafeLoader` loader