### PR TITLE
Pin Pika to less than 1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     install_requires=[
         'click>=6.6',
         'PyYAML>=5.1',
-        'pika>=0.10.0',
+        'pika<1.0.0',
         'slacker>=0.9.24',
     ],
     extras_require={
@@ -39,7 +39,6 @@ setup(
             "pytest",
             "pep8",
             "mock==2.0.0",
-            "black==19.3b0",
         ],
     },
     entry_points={


### PR DESCRIPTION
Temporary fix for issues with Pika version 1.0.0.

Remove black from DEV dependencies as version is not available for older Pythons