### PR TITLE
Move confing from a file to var.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include config/amqpeek.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ name = "amqpeek"
 version = "0.0.7"
 description = "A flexible RMQ monitor that keeps track of RMQ, notifying you over multiple channels when connections cannot be made, queues have not been declared, and when queue lengths increase beyond specified limits."
 authors = ["steveYeah <hutchinsteve@gmail.com>"]
-include = ["src/amqpeek-config/*.yaml"]
 license = "MIT"
 readme="README.md"
 homepage="https://github.com/steveYeah/amqpeek"

--- a/src/amqpeek/base_config.py
+++ b/src/amqpeek/base_config.py
@@ -1,3 +1,8 @@
+"""A Template for the base config."""
+
+DEFAULT_LOCATION = "amqpeek.yaml"
+
+BASE_CONFIG = """
 # RMQ connection details
 rabbit_connection: {
   user: guest,
@@ -62,3 +67,4 @@ notifiers:
       username: ampeek,
       channel: '#general'
   }
+"""

--- a/src/amqpeek/cli.py
+++ b/src/amqpeek/cli.py
@@ -3,17 +3,15 @@
 import logging
 import os
 import sys
-from shutil import copyfile
 from typing import List
 
 import click
 import yaml
 
+from .base_config import BASE_CONFIG, DEFAULT_LOCATION
 from .exceptions import ConfigExistsError
 from .monitor import Connector, Monitor
 from .notifier import create_notifiers
-
-DEFAULT_CONFIG = "amqpeek.yaml"
 
 
 def gen_config_file() -> None:
@@ -22,12 +20,11 @@ def gen_config_file() -> None:
     Raises:
         ConfigExistsError: When the config already exists
     """
-    if os.path.exists(DEFAULT_CONFIG):
+    if os.path.exists(DEFAULT_LOCATION):
         raise ConfigExistsError("File already exists")
 
-    this_file = os.path.dirname(os.path.realpath(__file__))
-    config_file = "{0}/../amqpeek-config/amqpeek.yaml".format(this_file)
-    copyfile(config_file, DEFAULT_CONFIG)
+    with open(DEFAULT_LOCATION, "w") as cf:
+        cf.write(BASE_CONFIG)
 
 
 def read_config(config_file_name: str) -> dict:
@@ -84,7 +81,7 @@ def build_queue_data(app_config: dict) -> List[tuple]:
 @click.option(
     "--config",
     "-c",
-    default=DEFAULT_CONFIG,
+    default=DEFAULT_LOCATION,
     help=(
         "Location of configuration file to use "
         '(defaults to "amqpeek.yaml" in current directory)'

--- a/tests/unit/cli/test_create_file.py
+++ b/tests/unit/cli/test_create_file.py
@@ -1,8 +1,9 @@
 """Tests the create config command."""
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
+from amqpeek.base_config import BASE_CONFIG, DEFAULT_LOCATION
 from amqpeek.cli import gen_config_file
 from amqpeek.exceptions import ConfigExistsError
 
@@ -19,21 +20,16 @@ class TestGenConfigFile:
             gen_config_file()
 
     @patch("amqpeek.cli.os.path.exists")
-    @patch("amqpeek.cli.copyfile")
-    @patch("amqpeek.cli.os.path.dirname")
+    @patch("amqpeek.cli.open", new_callable=mock_open)
     def test_file_created(
         self,
-        path_dirname_patch: MagicMock,
-        copyfile_patch: MagicMock,
+        open_patch: MagicMock,
         path_exists_patch: MagicMock,
     ) -> None:
         """Test the file is actually created."""
         path_exists_patch.return_value = False
-        this_file = "current_file_location"
-
-        path_dirname_patch.return_value = this_file
-        config_file = "{0}/../amqpeek-config/amqpeek.yaml".format(this_file)
 
         gen_config_file()
 
-        copyfile_patch.assert_called_once_with(config_file, "amqpeek.yaml")
+        open_patch.assert_called_with(DEFAULT_LOCATION, "w")
+        open_patch.return_value.write.assert_called_once_with(BASE_CONFIG)


### PR DESCRIPTION
It's a pain in the arse trying to package up a config file, it's tricky
to set it's default location when installing meaning the relationship
between the code and the config file, in terms of location, has to be
maintained so that it can be found.

To get around this, I've moved the config to code which is much eaiser
to control
